### PR TITLE
Fixed prowler microteleport bug

### DIFF
--- a/src/server/modes/base/maintenance/players/update.ts
+++ b/src/server/modes/base/maintenance/players/update.ts
@@ -643,6 +643,7 @@ export default class GamePlayersUpdate extends System {
             player.planestate.stealthed = false;
             player.times.lastStealth = now;
             player.delayed.BROADCAST_EVENT_STEALTH = true;
+            this.delay(BROADCAST_PLAYER_UPDATE, player.id.current);
           }
 
           const FIRE_TEMPLATE = SHIP_SPECS[fireMode][fireType];


### PR DESCRIPTION
This is for the issue described in https://github.com/steamroller-airmash/airmash-server/issues/98, which also affects ab-server. 

The fix attempts to match original server behaviour, emitting PLAYER_UPDATE immediately before PLAYER_FIRE.