### PR TITLE
Remove restrictions on session field of LOGIN packet

### DIFF
--- a/src/server/modes/base/controllers/login.ts
+++ b/src/server/modes/base/controllers/login.ts
@@ -70,14 +70,6 @@ export default class LoginMessageHandler extends System {
       return;
     }
 
-    if (msg.session.length > 0 && msg.session !== 'none') {
-      if (!user) {
-        this.emit(ERRORS_INVALID_LOGIN_DATA, connectionId);
-
-        return;
-      }
-    }
-
     name = name
       .replace(/[^\x20-\x7E]/g, '')
       .replace(/\s{2,}/g, ' ')


### PR DESCRIPTION
I would like to experiment with using this field to pass session information from the client to the server, but the ab-server currently only accepts the string "none" in this field.

I propose removing this check to avoid compatibility issues with divergent servers and clients.