### PR TITLE
#42: CTF: share in score based on time active on winning team

### DIFF
--- a/src/server/components/times.ts
+++ b/src/server/components/times.ts
@@ -26,9 +26,13 @@ export default class Times extends Component {
   public lastBounce = 0;
 
   /**
-   * ms.
+   * times active in ms.
    */
   public activePlaying = 0;
+
+  public activePlayingRed = 0;
+
+  public activePlayingBlue = 0;
 
   constructor() {
     super();

--- a/src/server/modes/base/maintenance/players/connect.ts
+++ b/src/server/modes/base/maintenance/players/connect.ts
@@ -214,6 +214,8 @@ export default class GamePlayersConnect extends System {
         player.score.current = recover.data.score;
 
         player.times.activePlaying = recover.data.activePlaying;
+        player.times.activePlayingBlue = recover.data.activePlayingBlue;
+        player.times.activePlayingRed = recover.data.activePlayingRed;
 
         this.log.debug(`Player id${player.id.current} data recovered.`);
       } else {

--- a/src/server/modes/base/maintenance/players/disconnect.ts
+++ b/src/server/modes/base/maintenance/players/disconnect.ts
@@ -84,6 +84,8 @@ export default class GamePlayersDisconnect extends System {
 
             lastSwitch: player.times.lastSwitch,
             activePlaying: player.times.activePlaying,
+            activePlayingRed: player.times.activePlayingRed,
+            activePlayingBlue: player.times.activePlayingBlue,
           },
         });
 

--- a/src/server/modes/base/maintenance/players/update.ts
+++ b/src/server/modes/base/maintenance/players/update.ts
@@ -1,5 +1,5 @@
 import { Polygon } from 'collisions';
-import { FLAGS_ISO_TO_CODE } from '@airbattle/protocol';
+import { FLAGS_ISO_TO_CODE, CTF_TEAMS } from '@airbattle/protocol';
 import {
   COLLISIONS_OBJECT_TYPES,
   MAP_SIZE,
@@ -284,6 +284,12 @@ export default class GamePlayersUpdate extends System {
         // rounded tick time 16.6ms.
         player.times.activePlaying += 17;
         player.times.lastMove = now;
+
+        if (player.team.current === CTF_TEAMS.RED) {
+          player.times.activePlayingRed += 17;
+        } else if (player.team.current === CTF_TEAMS.BLUE) {
+          player.times.activePlayingBlue += 17;
+        }
       }
 
       /**


### PR DESCRIPTION
Added bookkeeping on how long a player is active on both teams. This will be used to calculate the score for this player when the CTF game ends. Consequences:

- last minute switches won't matter much
- switches to help a team out won't be punished if you still lose the game (you will still share in the winning team score based on how long you were active on that team)
- inactive players using spectate scripts won't be rewarded, since they are 0 active on either side.