### PR TITLE
CTF: optionally change the mechanic of capture

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -157,6 +157,10 @@ export interface GameServerConfigInterface {
     tls: boolean;
   };
 
+  ctf: {
+    capIfReturned: boolean;
+  };
+
   /**
    * Maxmind DB.
    */
@@ -355,6 +359,10 @@ const config: GameServerConfigInterface = {
     host: strValue(process.env.MASTER_HOST),
     secret: strValue(process.env.MASTER_SECRET),
     tls: boolValue(process.env.MASTER_TLS, false),
+  },
+
+  ctf: {
+    capIfReturned: boolValue(process.env.CAP_IF_RETURNED, false),
   },
 
   geoBasePath: resolvePath(SERVER_DEFAULT_GEO_DB_PATH),

--- a/src/server/components/game/match.ts
+++ b/src/server/components/game/match.ts
@@ -1,4 +1,5 @@
 import Component from '@/server/component';
+import config from '@/config';
 
 export default class Match extends Component {
   public winnerTeam: number;
@@ -21,10 +22,13 @@ export default class Match extends Component {
 
   public current = 1;
 
+  public capIfReturned = false;
+
   constructor() {
     super();
 
     this.winnerTeam = 0;
     this.bounty = 0;
+    this.capIfReturned = config.ctf.capIfReturned;
   }
 }

--- a/src/server/modes/ctf/commands/match.ts
+++ b/src/server/modes/ctf/commands/match.ts
@@ -17,6 +17,7 @@ export default class MatchCommandHandler extends System {
     }
 
     const connection = this.storage.connectionList.get(connectionId);
+    const player = this.storage.playerList.get(connection.meta.playerId);
 
     if (command === '') {
       this.log.debug(`Player id${connection.meta.playerId} checked match info.`);
@@ -39,11 +40,30 @@ export default class MatchCommandHandler extends System {
         humanTimeParts.push(`${seconds}s`);
       }
 
+      const { capIfReturned } = this.storage.gameEntity.match;
+
       this.emit(
         BROADCAST_CHAT_SERVER_WHISPER,
         connection.meta.playerId,
-        `Match time: ${humanTimeParts.join(' ')}.`
+        `Match time: ${humanTimeParts.join(' ')}, cap_if_returned: ${capIfReturned}.`
       );
+    } else if (command.startsWith('set ')) {
+      if (player.su.current === false) {
+        return;
+      }
+
+      const varWithVal = command.substring('set '.length);
+
+      if (varWithVal.startsWith('cap_if_returned ')) {
+        const val = !!parseInt(varWithVal.substring('cap_if_returned '.length), 10);
+
+        this.storage.gameEntity.match.capIfReturned = val;
+        this.emit(
+          BROADCAST_CHAT_SERVER_WHISPER,
+          connection.meta.playerId,
+          `set cap_if_returned to ${val}`
+        );
+      }
     }
   }
 }

--- a/src/server/modes/ctf/maintenance/flags.ts
+++ b/src/server/modes/ctf/maintenance/flags.ts
@@ -310,6 +310,18 @@ export default class GameFlags extends System {
     const zone = this.storage.mobList.get(zoneId);
 
     if (zone.team.current === player.team.current) {
+      if (this.storage.gameEntity.match.capIfReturned) {
+        const teamFlag = this.storage.mobList.get(
+          player.team.current === CTF_TEAMS.BLUE
+            ? this.storage.ctfFlagBlueId
+            : this.storage.ctfFlagRedId
+        );
+
+        if (!teamFlag.flagstate.returned) {
+          return;
+        }
+      }
+
       const flag = this.storage.mobList.get(
         player.team.current === CTF_TEAMS.BLUE
           ? this.storage.ctfFlagRedId


### PR DESCRIPTION
Hi, I've  added option to enable capture of the flag only when your team's flag is at its spawn point.
Also added sub-command to `/match` for setting this option. It is disabled by default.
Implementation of  this idea https://github.com/airmash-refugees/game-ideas/issues/15
What do you think?
