### PR TITLE
Changes to IP banning

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -211,6 +211,11 @@ export interface GameServerConfigInterface {
   welcomeMessages: string[];
 
   /**
+   * Permit automatic bans based on network events (i.e. packet flooding).
+   */
+  autoBan: boolean;
+
+  /**
    * Server version.
    */
   version: string;
@@ -392,6 +397,8 @@ const config: GameServerConfigInterface = {
   maxPlayersPerIP: intValue(process.env.MAX_PLAYERS_PER_IP, CONNECTIONS_DEFAULT_MAX_PLAYERS_PER_IP),
 
   welcomeMessages: parseWelcomeMessages(process.env.WELCOME_MESSAGES, SERVER_WELCOME_MESSAGES),
+
+  autoBan: boolValue(process.env.AUTOBAN_ENABLED, false),
 
   version,
 };

--- a/src/server/modes/base/guards/packets.ts
+++ b/src/server/modes/base/guards/packets.ts
@@ -82,7 +82,7 @@ export default class PacketsGuard extends System {
       connection: connection.meta.id,
     });
 
-    if (floodCounter >= CONNECTIONS_FLOOD_DETECTS_TO_BAN) {
+    if (this.app.config.autoBan && floodCounter >= CONNECTIONS_FLOOD_DETECTS_TO_BAN) {
       this.log.info('Packet flooding ban.', {
         ip: connection.meta.ip,
         connection: connection.meta.id,

--- a/src/server/modes/base/responses/ban.ts
+++ b/src/server/modes/base/responses/ban.ts
@@ -17,12 +17,12 @@ export default class PlayerBanResponse extends System {
    * @param connectionId
    * @param type
    */
-  onPlayerLevel(connectionId: ConnectionId): void {
+  onPlayerLevel(connectionId: ConnectionId, isPacketFloodingBan: boolean): void {
     this.emit(
       CONNECTIONS_SEND_PACKET,
       {
         c: SERVER_PACKETS.ERROR,
-        error: SERVER_ERRORS.GLOBAL_BAN,
+        error: isPacketFloodingBan ? SERVER_ERRORS.PACKET_FLOODING_BAN : SERVER_ERRORS.GLOBAL_BAN,
       } as ServerPackets.Error,
       connectionId
     );


### PR DESCRIPTION
1. Allow server operators to configure automatic IP banning with the `AUTOBAN_ENABLED` variable.

2. If a player is banned for packet flooding, send a `PACKET_FLOODING_BAN` error in any future error packets if they reconnect (rather than `GLOBAL_BAN` which should be only for moderator-triggered bans).