### PR TITLE
Check empty password

### DIFF
--- a/src/endpoints/ws.ts
+++ b/src/endpoints/ws.ts
@@ -411,6 +411,8 @@ export default class WsEndpoint {
   }
 
   protected async getModeratorByPassword(password: string): Promise<string | boolean> {
+    if (!password) return false;
+    
     let file = null;
 
     try {


### PR DESCRIPTION
If the body is empty in the post request to the endpoint `admin/matches`, then the password is undefined.
If passwords file contains new line in the end of the file (e.g. vim adds it automatically) then there will be undefined `test` variable too...