### PR TITLE
Send server configuration data to client upon login

### DIFF
--- a/src/server/modes/base/maintenance/players/connect.ts
+++ b/src/server/modes/base/maintenance/players/connect.ts
@@ -1,4 +1,10 @@
-import { GAME_TYPES, PLAYER_LEVEL_UPDATE_TYPES } from '@airbattle/protocol';
+import {
+  GAME_TYPES,
+  PLAYER_LEVEL_UPDATE_TYPES,
+  ServerPackets,
+  SERVER_CUSTOM_TYPES,
+  SERVER_PACKETS,
+} from '@airbattle/protocol';
 import { Polygon } from 'collisions';
 import {
   CHAT_USERNAME_PLACEHOLDER,
@@ -41,6 +47,7 @@ import {
   TIMEOUT_ACK,
   TIMEOUT_BACKUP,
   VIEWPORTS_CREATE,
+  CONNECTIONS_SEND_PACKET,
 } from '@/events';
 import { CHANNEL_CONNECT_PLAYER, CHANNEL_MUTE } from '@/server/channels';
 import AliveStatus from '@/server/components/alive-status';
@@ -420,6 +427,31 @@ export default class GamePlayersConnect extends System {
      * Broadcasts.
      */
     this.emit(RESPONSE_LOGIN, connectionId);
+
+    /**
+     * Server configuration data
+     */
+    const config: any = {};
+
+    config.sf = this.app.config.server.scaleFactor;
+
+    if (this.app.config.afkDisconnectTimeout) {
+      config.afk = this.app.config.afkDisconnectTimeout;
+    }
+
+    this.emit(
+      CONNECTIONS_SEND_PACKET,
+      {
+        c: SERVER_PACKETS.SERVER_CUSTOM,
+        type: SERVER_CUSTOM_TYPES.SERVER_CONFIG,
+        data: JSON.stringify(config),
+      } as ServerPackets.ServerCustom,
+      connectionId
+    );
+
+    /**
+     * More broadcasts
+     */
     this.emit(BROADCAST_PLAYER_NEW, player.id.current);
     this.emit(BROADCAST_SCORE_BOARD, connectionId);
     this.emit(RESPONSE_SEND_PING, connectionId);


### PR DESCRIPTION
This is for server configuration that would be useful for the client to know. Currently:

| Name | Description | Purpose |
|:- |:- |:- |
| sf | Scale factor limit | Client may limit or warn when its scale factor exceeds this |
| afk | AFK disconnection timeout | Client may provide a custom error message |

I'm currently testing this on eu.airmash.online game servers and https://test.airmash.online client, but will revert if this PR is not a suitable approach.