### PR TITLE
Fix delayed appearance of scoreboard

### DIFF
--- a/src/server/modes/base/maintenance/players/connect.ts
+++ b/src/server/modes/base/maintenance/players/connect.ts
@@ -453,7 +453,6 @@ export default class GamePlayersConnect extends System {
      * More broadcasts
      */
     this.emit(BROADCAST_PLAYER_NEW, player.id.current);
-    this.emit(BROADCAST_SCORE_BOARD, connectionId);
     this.emit(RESPONSE_SEND_PING, connectionId);
     this.emit(PLAYERS_APPLY_SHIELD, player.id.current, PLAYERS_SPAWN_SHIELD_DURATION_MS);
 
@@ -468,6 +467,7 @@ export default class GamePlayersConnect extends System {
     }
 
     this.emit(PLAYERS_CREATED, player.id.current);
+    this.emit(BROADCAST_SCORE_BOARD, connectionId);
 
     if (isRecovered === true) {
       let hasUpgrades = false;


### PR DESCRIPTION
This changes `GamePlayersConnect` system to emit `BROADCAST_SCORE_BOARD` after `PLAYERS_CREATED`, so the `GameRankings` system can add the player to `this.storage.playerRankings.byBounty` before it's used to make the scoreboard. Otherwise the frontend will not display the first `SCORE_BOARD` packet, as it doesn't contain the player.

https://github.com/airmash-refugees/airmash-frontend/blob/b5c8685f926025c9ea4b02b0c67d1e5f0ca9ff28/src/js/UI.js#L375-L377