### PR TITLE
Send server configuration in LOGIN packet

### DIFF
--- a/src/server/modes/base/maintenance/players/connect.ts
+++ b/src/server/modes/base/maintenance/players/connect.ts
@@ -435,39 +435,6 @@ export default class GamePlayersConnect extends System {
      * Broadcasts.
      */
     this.emit(RESPONSE_LOGIN, connectionId);
-
-    /**
-     * Server configuration data
-     */
-    if (
-      !(
-        this.app.config.server.typeId === GAME_TYPES.CTF &&
-        mainConnection.meta.isBot === true &&
-        this.app.config.ctfQBotsFeatures === true
-      )
-    ) {
-      const config: any = {};
-
-      config.sf = this.app.config.server.scaleFactor;
-
-      if (this.app.config.afkDisconnectTimeout) {
-        config.afk = this.app.config.afkDisconnectTimeout;
-      }
-
-      this.emit(
-        CONNECTIONS_SEND_PACKET,
-        {
-          c: SERVER_PACKETS.SERVER_CUSTOM,
-          type: SERVER_CUSTOM_TYPES.SERVER_CONFIG,
-          data: JSON.stringify(config),
-        } as ServerPackets.ServerCustom,
-        connectionId
-      );
-    }
-
-    /**
-     * More broadcasts
-     */
     this.emit(BROADCAST_PLAYER_NEW, player.id.current);
     this.emit(RESPONSE_SEND_PING, connectionId);
     this.emit(PLAYERS_APPLY_SHIELD, player.id.current, PLAYERS_SPAWN_SHIELD_DURATION_MS);

--- a/src/server/modes/base/responses/login.ts
+++ b/src/server/modes/base/responses/login.ts
@@ -49,6 +49,19 @@ export default class LoginResponse extends System {
       }
     });
 
+    /**
+     * Server configuration data
+     */
+    const config: any = {};
+
+    config.sf = this.app.config.server.scaleFactor;
+
+    if (this.app.config.afkDisconnectTimeout) {
+      config.afk = this.app.config.afkDisconnectTimeout;
+    }
+
+    config.botsNamePrefix = this.app.config.botsNamePrefix;
+
     this.emit(
       CONNECTIONS_SEND_PACKET,
       {
@@ -61,7 +74,7 @@ export default class LoginResponse extends System {
         type: this.app.config.server.typeId,
         room: this.app.config.server.room,
         players,
-        botsNamePrefix: this.app.config.botsNamePrefix,
+        serverConfiguration: JSON.stringify(config),
         bots,
       } as ServerPackets.Login,
       connectionId


### PR DESCRIPTION
Configuration data now includes botsNamePrefix

SERVER_CONFIG type of SERVER_CUSTOM packet is no longer used

https://github.com/wight-airmash/ab-protocol/pull/7