### PR TITLE
Supporting CIDR as a valid input for bot IPs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,11 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/netmask": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@types/netmask/-/netmask-1.0.30.tgz",
+      "integrity": "sha512-Kl1xAICLv1Y7/WsNXkPKldRMz3QmXUYMIzr3rMXnIBDy9c4/sYG7V6P6u7Ja3w+uNtNQrRudJduqVoYX/DxfZg=="
+    },
     "@types/node": {
       "version": "12.12.47",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
@@ -1217,6 +1222,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "netmask": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
   },
   "dependencies": {
     "@airbattle/protocol": "github:wight-airmash/ab-protocol#v6.0.0",
+    "@types/netmask": "^1.0.30",
     "collisions": "github:wight-airmash/ab-collisions#v2.0.14-ab.6.1",
     "dotenv": "^8.2.0",
     "eventemitter3": "^4.0.4",
     "fast-json-stringify": "^2.2.0",
     "maxmind": "^4.1.3",
+    "netmask": "^1.0.6",
     "pino": "^6.3.2",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v17.6.0"
   },


### PR DESCRIPTION
I'm running the bots in a separate pod in Kubernetes and the IP
addresses are variable within a subnet. This change takes a CIDR as
and input and expands it to get all the IP addresses in range,
adding them to the bot ip list.