### PR TITLE
Votemute enhancements to prevent abuse

### DIFF
--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -80,11 +80,11 @@ Votemute abuse prevention. Requires voters to have a score exceeding the provide
 Valid values are in the range `[0.0, 1.0)`. Recommended value is `0.5`.
 
 
-### CHAT_MIN_PLAYER_PLAYTIME_TO_VOTEMUTE_MS
+### CHAT_MIN_PLAYER_PLAYTIME_TO_VOTEMUTE
 
-Default: 60000
+Default: 60
 
-To use /votemute, player must play at least this time duration.
+To use /votemute, player must play at least this many seconds.
 
 
 ### CTF_BASE_SHIELD_RANDOM_INTERVAL

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -70,6 +70,23 @@ Path to the certificates directory. Relative (to `app.js` [root](#app-root)) or 
 
 Must contain `privkey.pem` and `fullchain.pem` files (if `ENDPOINTS_TLS` is `true`).
 
+
+### CHAT_MIN_PLAYER_SCORE_TO_VOTEMUTE
+
+Default: 0.0
+
+Votemute abuse prevention. Requires voters to have a score exceeding the provided threshold percentile. 
+
+Valid values are in the range `[0.0, 1.0)`. Recommended value is `0.5`.
+
+
+### CHAT_MIN_PLAYER_PLAYTIME_TO_VOTEMUTE_MS
+
+Default: 60000
+
+To use /votemute, player must play at least this time duration.
+
+
 ### CTF_BASE_SHIELD_RANDOM_INTERVAL
 
 Default: `30`

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync } from 'fs';
 import { dirname, isAbsolute, resolve } from 'path';
 import { FLAGS_ISO_TO_CODE, GAME_TYPES } from '@airbattle/protocol';
+import { MS_PER_SEC } from '../constants'
 import dotenv from 'dotenv';
 import {
   AUTH_LOGIN_SERVER_KEY_URL,
@@ -480,7 +481,7 @@ const config: GameServerConfigInterface = {
      * To use /votemute player must play (not spectate, not stay) at least this time duration.
      */
     votemutePercentile: floatValue(process.env.CHAT_MIN_PLAYER_SCORE_TO_VOTEMUTE, 0.0),
-    votemuteDuration: intValue(process.env.CHAT_MIN_PLAYER_PLAYTIME_TO_VOTEMUTE_MS, 60000),
+    votemuteDuration: intValue(process.env.CHAT_MIN_PLAYER_PLAYTIME_TO_VOTEMUTE, 60) * MS_PER_SEC,
   },
 
   logs: {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -140,6 +140,11 @@ export interface GameServerConfigInterface {
     };
   };
 
+  chat: {
+    votemutePercentile: number;
+    votemuteDuration: number;
+  }
+
   logs: {
     level: string;
 
@@ -463,9 +468,19 @@ const config: GameServerConfigInterface = {
     bot: {
       name: strValue(process.env.SERVER_BOT_NAME, BOTS_SERVER_BOT_NAME),
       flag: strValue(process.env.SERVER_BOT_FLAG, BOTS_SERVER_BOT_FLAG),
+
       flagId: 0,
       welcome: parseWelcomeMessages(process.env.WELCOME_MESSAGES, SERVER_WELCOME_MESSAGES),
     },
+  },
+
+  chat: {
+    /**
+     * To use /votemute player score must be in the top N-tile of all players.
+     * To use /votemute player must play (not spectate, not stay) at least this time duration.
+     */
+    votemutePercentile: floatValue(process.env.CHAT_MIN_PLAYER_SCORE_TO_VOTEMUTE, 0.0),
+    votemuteDuration: intValue(process.env.CHAT_MIN_PLAYER_PLAYTIME_TO_VOTEMUTE_MS, 60000),
   },
 
   logs: {

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -10,16 +10,6 @@ export const CHAT_MUTE_TIME_MS = 10 * SECONDS_PER_MINUTE * MS_PER_SEC;
 export const CHAT_SUPERUSER_MUTE_TIME_MS = 60 * SECONDS_PER_MINUTE * MS_PER_SEC;
 
 /**
- * To use /votemute player must play (not spectate, not stay) at least this time duration.
- */
-export const CHAT_MIN_PLAYER_PLAYTIME_TO_VOTEMUTE_MS = 60 * MS_PER_SEC;
-
-/**
- * To use /votemute, player score must be in the top 50% of all players
- */
-export const CHAT_MIN_PLAYER_SCORE_TO_VOTEMUTE = 0.50; 
-
-/**
  * StarMash client has built-in anti-spam, it rejects whisper messages
  * that comes within first seconds after joining the game.
  */

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -15,6 +15,11 @@ export const CHAT_SUPERUSER_MUTE_TIME_MS = 60 * SECONDS_PER_MINUTE * MS_PER_SEC;
 export const CHAT_MIN_PLAYER_PLAYTIME_TO_VOTEMUTE_MS = 60 * MS_PER_SEC;
 
 /**
+ * To use /votemute, player score must be in the top 50% of all players
+ */
+export const CHAT_MIN_PLAYER_SCORE_TO_VOTEMUTE = 0.50; 
+
+/**
  * StarMash client has built-in anti-spam, it rejects whisper messages
  * that comes within first seconds after joining the game.
  */

--- a/src/endpoints/ws.ts
+++ b/src/endpoints/ws.ts
@@ -235,6 +235,8 @@ export default class WsEndpoint {
 
     const { ip } = connection;
 
+    this.log.info('okay now');
+
     /**
      * Detect bots.
      */
@@ -456,13 +458,18 @@ export default class WsEndpoint {
   }
 
   private bindWebsocketHandlers(): void {
-    this.uws.ws(`${this.path}/`, {
+    this.log.error('what the everliving fuck')
+    this.uws.ws('*', {
+
       compression: this.config.server.compression ? CONNECTIONS_WEBSOCKETS_COMPRESSOR : DISABLED,
       maxPayloadLength: CONNECTIONS_MAX_PAYLOAD_BYTES,
       maxBackpressure: CONNECTIONS_MAX_BACKPRESSURE,
       idleTimeout: CONNECTIONS_IDLE_TIMEOUT_SEC,
 
       open: (connection: PlayerConnection, req) => {
+
+        this.log.error('what the heck is even happening?', {});
+
         const connectionId = this.createConnectionId();
         const now = Date.now();
         const meta: WorkerConnectionMeta = {
@@ -538,6 +545,9 @@ export default class WsEndpoint {
       })
 
       .get(`${this.path}/`, res => {
+
+        this.log.error('y tho');
+
         const gameModeResponse =
           this.storage.gameModeAPIResponse === '' ? '' : `,${this.storage.gameModeAPIResponse}`;
 

--- a/src/endpoints/ws.ts
+++ b/src/endpoints/ws.ts
@@ -235,8 +235,6 @@ export default class WsEndpoint {
 
     const { ip } = connection;
 
-    this.log.info('okay now');
-
     /**
      * Detect bots.
      */
@@ -458,18 +456,13 @@ export default class WsEndpoint {
   }
 
   private bindWebsocketHandlers(): void {
-    this.log.error('what the everliving fuck')
-    this.uws.ws('*', {
-
+    this.uws.ws(`${this.path}/`, {
       compression: this.config.server.compression ? CONNECTIONS_WEBSOCKETS_COMPRESSOR : DISABLED,
       maxPayloadLength: CONNECTIONS_MAX_PAYLOAD_BYTES,
       maxBackpressure: CONNECTIONS_MAX_BACKPRESSURE,
       idleTimeout: CONNECTIONS_IDLE_TIMEOUT_SEC,
 
       open: (connection: PlayerConnection, req) => {
-
-        this.log.error('what the heck is even happening?', {});
-
         const connectionId = this.createConnectionId();
         const now = Date.now();
         const meta: WorkerConnectionMeta = {
@@ -545,9 +538,6 @@ export default class WsEndpoint {
       })
 
       .get(`${this.path}/`, res => {
-
-        this.log.error('y tho');
-
         const gameModeResponse =
           this.storage.gameModeAPIResponse === '' ? '' : `,${this.storage.gameModeAPIResponse}`;
 

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -289,6 +289,17 @@ export class GameStorage {
   public playerRankings: RankingsStorage = {
     outdated: false,
     byBounty: [],
+
+    /**
+     * scoreAtNtile returns the score at the Nth percentile from the byBounty array.
+     */
+    scoreAtPercentile: (n) => {
+      let idx = Math.round((this.playerRankings.byBounty.length * (1-n)) - 1) 
+      if (idx < this.playerRankings.byBounty.length && idx > 0) {
+        return this.playerRankings.byBounty[idx].score;
+      }
+      return -1
+    }
   };
 
   public gameModeAPIResponse = '';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -305,6 +305,7 @@ export interface BountyRankingItem {
 export interface RankingsStorage {
   outdated: boolean;
   byBounty: BountyRankingItem[];
+  scoreAtPercentile(n: number): number
 }
 
 export interface CTFLeadersStorage {


### PR DESCRIPTION
This PR updates the votemute logic with an additional check to ensure that the player voting to mute has a score above a certain percentile of all players on the server. In effect, this helps to ensure that votemuting another player requires "skin in the game". 

When a player attempts to mute, the server will compute a list of all scores and identify the "score to beat" from that set. The score to beat is the score at or below a threshold percentile. Players whose score is below this threshold will be asked to try harder and vote again. The error message by design does not tell them what to strive for.

- Score threshold tabulation added to mute.ts
- votemute settings CHAT_MIN_PLAYER_SCORE_TO_VOTEMUTE and CHAT_MIN_PLAYER_TIME_TO_VOTEMUTE_MS have been plumbed up as env vars
- Default value for this feature is that it is disabled
- Documentation updated
