### PR TITLE
Added 'upgrades fever' server command.

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -290,6 +290,11 @@ export interface GameServerConfigInterface {
      * Set min = 0 and max = 0 to disable upgrades drop.
      */
     maxChance: number;
+
+    /**
+     * Fever indicates all users respawn with full boosts
+     */
+    fever: boolean;
   };
 
   /**
@@ -571,6 +576,7 @@ const config: GameServerConfigInterface = {
   upgrades: {
     minChance: floatValue(process.env.UPGRADES_DROP_MIN_CHANCE, UPGRADES_DEFAULT_MIN_CHANCE),
     maxChance: floatValue(process.env.UPGRADES_DROP_MAX_CHANCE, UPGRADES_DEFAULT_MAX_CHANCE),
+    fever: false,
   },
 
   visibleTeamProwlers: boolValue(

--- a/src/server/commands/server.ts
+++ b/src/server/commands/server.ts
@@ -32,6 +32,7 @@ import { numberToHumanReadable } from '../../support/numbers';
 import { has } from '../../support/objects';
 import { ConnectionId, ConnectionMeta, MainConnectionId, PlayerId } from '../../types';
 import { System } from '../system';
+import { applyUpgradeFever } from '../maintenance/players/upgrades'
 
 export default class ServerCommandHandler extends System {
   private cfg: GameServerConfigInterface;
@@ -775,19 +776,7 @@ export default class ServerCommandHandler extends System {
           return;
         }
 
-        let v = this.config.upgrades.fever ? player.bot.current ? 3 : 5 : 0;
-        if (v !== 0) {
-          player.upgrades.amount = player.upgrades.amount + 
-            player.upgrades.speed +
-            player.upgrades.defense +
-            player.upgrades.energy +
-            player.upgrades.missile
-        }
-
-        player.upgrades.speed = v;
-        player.upgrades.defense = v;
-        player.upgrades.energy = v;
-        player.upgrades.missile = v;
+        applyUpgradeFever(player, this.config.upgrades.fever)
         this.emit(RESPONSE_PLAYER_UPGRADE, player.id.current, UPGRADES_ACTION_TYPE.LOST);
       })
     }

--- a/src/server/commands/server.ts
+++ b/src/server/commands/server.ts
@@ -9,6 +9,7 @@ import {
   SECONDS_PER_HOUR,
   SECONDS_PER_MINUTE,
   SERVER_MIN_SERVICE_MOB_ID,
+  UPGRADES_ACTION_TYPE,
 } from '../../constants';
 import {
   BROADCAST_CHAT_SERVER_PUBLIC,
@@ -23,6 +24,7 @@ import {
   PLAYERS_KICK,
   POWERUPS_UPDATE_CONFIG,
   RESPONSE_COMMAND_REPLY,
+  RESPONSE_PLAYER_UPGRADE,
 } from '../../events';
 import { Metrics } from '../../logger/metrics';
 import { msToHumanReadable } from '../../support/datetime';
@@ -754,6 +756,42 @@ export default class ServerCommandHandler extends System {
     playerId: PlayerId,
     command: string
   ): void {
+
+    /**
+     * upgrades fever starts an upgrade fever event. The duration is indefinite. 
+     * 
+     * When the event begins, each player's current upgrades are tallied and stored,
+     * then their upgrades are all set to 5. Bots get set to 3. There is an additional
+     * check in respawn.js to set upgrades to 5 when fever is ongoing. 
+     * 
+     */
+    if (command.indexOf('upgrades fever') === 0) {
+      let verb = this.config.upgrades.fever ? 'ended' : 'started'
+      this.config.upgrades.fever = !this.config.upgrades.fever
+      this.emit(BROADCAST_CHAT_SERVER_PUBLIC, 'Upgrades fever ' + verb)
+
+      this.storage.playerList.forEach((player) => {
+        if (!this.helpers.isPlayerConnected(player.id.current)) {
+          return;
+        }
+
+        let v = this.config.upgrades.fever ? player.bot.current ? 3 : 5 : 0;
+        if (v !== 0) {
+          player.upgrades.amount = player.upgrades.amount + 
+            player.upgrades.speed +
+            player.upgrades.defense +
+            player.upgrades.energy +
+            player.upgrades.missile
+        }
+
+        player.upgrades.speed = v;
+        player.upgrades.defense = v;
+        player.upgrades.energy = v;
+        player.upgrades.missile = v;
+        this.emit(RESPONSE_PLAYER_UPGRADE, player.id.current, UPGRADES_ACTION_TYPE.LOST);
+      })
+    }
+
     if (command.indexOf('upgrades min') === 0 && command.length > 13) {
       const value = parseFloat(command.substring(13));
 

--- a/src/server/maintenance/players/connect.ts
+++ b/src/server/maintenance/players/connect.ts
@@ -92,6 +92,7 @@ import Velocity from '../../components/velocity';
 import Wins from '../../components/wins';
 import Entity from '../../entity';
 import { System } from '../../system';
+import { applyUpgradeFever } from './upgrades'
 
 export default class GamePlayersConnect extends System {
   private framesPassedSinceLogin = 0;
@@ -249,12 +250,13 @@ export default class GamePlayersConnect extends System {
       player.level.current = convertEarningsToLevel(user.lifetimestats.earnings);
     }
 
-    this.log.info('Player connected: %o', {
+    this.log.info('Player fucktarded: %o', {
       playerId,
       name: uniqueName,
       ip: player.ip.current,
       connectionId,
     });
+
 
     /**
      * Player stats recovering after disconnection.
@@ -488,6 +490,15 @@ export default class GamePlayersConnect extends System {
         }were recovered after disconnection.`
       );
     }
+    applyUpgradeFever(player, this.config.upgrades.fever)
+    if (this.config.upgrades.fever) {
+      this.emit(
+        BROADCAST_CHAT_SERVER_WHISPER,
+        playerId,
+        `An upgrades fever event is ongoing`,
+      );
+    }
+    this.delay(RESPONSE_PLAYER_UPGRADE, playerId, UPGRADES_ACTION_TYPE.LOST);
 
     /**
      * Welcome messages.

--- a/src/server/maintenance/players/respawn.ts
+++ b/src/server/maintenance/players/respawn.ts
@@ -7,6 +7,7 @@ import {
   PLAYERS_RESPAWN_INACTIVITY_MS,
   PLAYERS_SPAWN_SHIELD_DURATION_MS,
   SHIPS_TYPES,
+  UPGRADES_ACTION_TYPE,
 } from '../../../constants';
 import {
   BROADCAST_PLAYER_RESPAWN,
@@ -21,6 +22,7 @@ import {
   PLAYERS_SET_SHIP_TYPE,
   PLAYERS_UPGRADES_RESET,
   RESPONSE_SPECTATE_KILL,
+  RESPONSE_PLAYER_UPGRADE,
   VIEWPORTS_UPDATE_POSITION,
 } from '../../../events';
 import { CHANNEL_RESPAWN_PLAYER } from '../../../events/channels';
@@ -137,6 +139,7 @@ export default class GamePlayersRespawn extends System {
       player.inferno.current = false;
       player.inferno.endTime = 0;
 
+
       const hitbox = this.storage.shipHitboxesCache[shipType][player.rotation.low];
 
       player.hitbox.width = hitbox.width;
@@ -174,6 +177,22 @@ export default class GamePlayersRespawn extends System {
 
       this.emit(BROADCAST_PLAYER_RESPAWN, player.id.current);
       this.emit(PLAYERS_APPLY_SHIELD, player.id.current, PLAYERS_SPAWN_SHIELD_DURATION_MS);
+
+      /**
+       * Check for upgrades fever and apply
+       */
+      if (this.config.upgrades.fever) {
+        let lvl = 5
+        if (player.bot.current) {
+          lvl = 3
+        }
+
+        player.upgrades.speed = lvl;
+        player.upgrades.defense = lvl;
+        player.upgrades.energy = lvl;
+        player.upgrades.missile = lvl;
+        this.emit(RESPONSE_PLAYER_UPGRADE, playerId, UPGRADES_ACTION_TYPE.LOST);
+      }
 
       /**
        * No spectating anymore.

--- a/src/server/maintenance/players/respawn.ts
+++ b/src/server/maintenance/players/respawn.ts
@@ -28,6 +28,7 @@ import {
 import { CHANNEL_RESPAWN_PLAYER } from '../../../events/channels';
 import { PlayerId } from '../../../types';
 import { System } from '../../system';
+import { applyUpgradeFever }from './upgrades';
 
 export default class GamePlayersRespawn extends System {
   constructor({ app }) {
@@ -181,18 +182,8 @@ export default class GamePlayersRespawn extends System {
       /**
        * Check for upgrades fever and apply
        */
-      if (this.config.upgrades.fever) {
-        let lvl = 5
-        if (player.bot.current) {
-          lvl = 3
-        }
-
-        player.upgrades.speed = lvl;
-        player.upgrades.defense = lvl;
-        player.upgrades.energy = lvl;
-        player.upgrades.missile = lvl;
-        this.emit(RESPONSE_PLAYER_UPGRADE, playerId, UPGRADES_ACTION_TYPE.LOST);
-      }
+      applyUpgradeFever(player, this.config.upgrades.fever)
+      this.emit(RESPONSE_PLAYER_UPGRADE, player.id.current, UPGRADES_ACTION_TYPE.LOST);
 
       /**
        * No spectating anymore.

--- a/src/server/maintenance/players/upgrades.ts
+++ b/src/server/maintenance/players/upgrades.ts
@@ -1,6 +1,6 @@
 import { UPGRADES_ACTION_TYPE } from '../../../constants';
 import { PLAYERS_UPGRADES_RESET, RESPONSE_PLAYER_UPGRADE } from '../../../events';
-import { PlayerId } from '../../../types';
+import { PlayerId, Player } from '../../../types';
 import { System } from '../../system';
 
 export default class GameUpgrades extends System {
@@ -23,3 +23,36 @@ export default class GameUpgrades extends System {
     this.delay(RESPONSE_PLAYER_UPGRADE, player.id.current, UPGRADES_ACTION_TYPE.LOST);
   }
 }
+
+export function applyUpgradeFever(player: Player, fever: Boolean): void {
+
+  if (fever) {
+    if (player.bot.current) {
+      // bots get a nerf
+      player.upgrades.speed = 3;
+      player.upgrades.defense = 2;
+      player.upgrades.energy = 3;
+      player.upgrades.missile = 3;
+
+    } else {
+      // preserve player upgrades
+      player.upgrades.amount = player.upgrades.amount + 
+        player.upgrades.speed +
+        player.upgrades.defense +
+        player.upgrades.energy +
+        player.upgrades.missile
+
+      // full boosts
+      player.upgrades.speed = 5;
+      player.upgrades.defense = 5;
+      player.upgrades.energy = 5;
+      player.upgrades.missile = 5;
+    }
+  } else {
+    player.upgrades.speed = 0;
+    player.upgrades.defense = 0;
+    player.upgrades.energy = 0;
+    player.upgrades.missile = 0;
+  }
+}
+


### PR DESCRIPTION
This command initiates an upgrade fever event. Design is intended for FFA but it works for CTF as well.

- new command 'server upgrades fever' starts the event
- current player upgrades are stored and values reset to 5
- on respawn, config.upgrades.fever is checked to max upgrades
- bots only get upgraded to 3/5
- event also ends with 'server upgrades fever'. it's a toggle

The only other thing I'm thinking of here is about how the fever event might be toggled from `server/periodic`. For FFA it could be fun to run an event every hour or so, for a few minutes. If that were the case I'd want to pull the logic out of server.js and into a separate function, and conditionally modify the welcome message so that new players are informed about the special condition. 

