### PR TITLE
Supporting variable spawn zones for FFA

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -264,3 +264,7 @@ Remove a message by the index from [/server welcome list](#server-welcome-list) 
 ### /server welcome flush
 
 Remove all the welcome messages from the list.
+
+### /server spawn <zone>
+
+Set an alternative spawn zone for FFA.  Valid zones are `europe`, `canada`, `latam`, and `asia`. 

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -108,6 +108,10 @@ Default: `undefined`
 
 It is preferable to set it `1` in the production, can affect performance. See uWebSockets.js. package repository for more info.
 
+### FFA_SPAWN_ZONE_NAME
+
+Set an alternative spawn zone for FFA.  Valid zones are `europe`, `canada`, `latam`, and `asia`. 
+
 ### HOST
 
 Default: `0.0.0.0`

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -321,6 +321,16 @@ export interface GameServerConfigInterface {
     randomBaseShieldInterval: number;
   };
 
+  ffa: {
+    /**
+     * Support alternative spawn zones at runtime.
+     * The provided string maps to an enumerated set of valid ffa spawn zones.
+     * If the string matches an available spawn zones, spawn events will take place in that zone.
+     * Otherwise, they will occur in the default EU spawn zone.
+     */
+    spawnZoneName: string; 
+  };
+
   bots: {
     /**
      * Enable or disable allowed IP list.
@@ -604,6 +614,10 @@ const config: GameServerConfigInterface = {
       process.env.CTF_BASE_SHIELD_RANDOM_INTERVAL,
       CTF_BASE_SHIELD_RANDOM_INTERVAL_SEC
     ),
+  },
+
+  ffa: {
+    spawnZoneName: strValue(process.env.FFA_SPAWN_ZONE_NAME, "europe"),
   },
 };
 

--- a/src/constants/ffa.ts
+++ b/src/constants/ffa.ts
@@ -22,7 +22,7 @@ export const FFA_SPAWN_LATAM: SpawnZone = {
   MAX_Y: -512 * -13,
 }
 
-export const FFA_SPAWN_RUSSIA: SpawnZone = {
+export const FFA_SPAWN_ASIA: SpawnZone = {
   MIN_X: -512 * -8,
   MAX_X: -512 * -16,
   MIN_Y: -512 * 6,

--- a/src/constants/ffa.ts
+++ b/src/constants/ffa.ts
@@ -1,8 +1,44 @@
 import { SpawnZone } from '../types';
 
+
 export const FFA_SPAWN_EUROPE: SpawnZone = {
   MIN_X: -512 * 2,
-  MIN_Y: -512 * 9,
   MAX_X: 512 * 6,
+  MIN_Y: -512 * 9,
   MAX_Y: -512,
 };
+
+export const FFA_SPAWN_CANADA: SpawnZone = {
+  MIN_X: -512 * 22,
+  MAX_X: -512 * 16,
+  MIN_Y: -512 * 11,
+  MAX_Y: -512 * 3,
+}
+
+export const FFA_SPAWN_LATAM: SpawnZone = {
+  MIN_X: -512 * 16,
+  MAX_X: -512 * 8,
+  MIN_Y: -512 * -5,
+  MAX_Y: -512 * -13,
+}
+
+export const FFA_SPAWN_RUSSIA: SpawnZone = {
+  MIN_X: -512 * -8,
+  MAX_X: -512 * -16,
+  MIN_Y: -512 * 6,
+  MAX_Y: -512 * -2,
+}
+
+/**
+ * These are indexes mapping a semantic name to the spawn zone positions 
+ * To add a new spawn zone, create a box above, reference the box in spawn.ts,
+ * and give it a name and index below.
+ * 
+ * Be sure to keep the spawn zone size constant. 8 x 8
+ */
+export const FFA_VALID_SPAWN_ZONES: Object = {
+  "europe": 0,
+  "canada": 1,
+  "latam": 2,
+  "asia": 3,
+}

--- a/src/constants/spawn.ts
+++ b/src/constants/spawn.ts
@@ -1,12 +1,12 @@
 import { GAME_TYPES } from '@airbattle/protocol';
 import { SpawnZonesTemplate } from '../types';
 import { BTR_SPAWN_MATCH_START, BTR_SPAWN_WAITING } from './btr';
-import { FFA_SPAWN_EUROPE, FFA_SPAWN_CANADA, FFA_SPAWN_LATAM, FFA_SPAWN_RUSSIA } from './ffa';
+import { FFA_SPAWN_EUROPE, FFA_SPAWN_CANADA, FFA_SPAWN_LATAM, FFA_SPAWN_ASIA } from './ffa';
 
 /**
  * CTF has a custom spawn system. See `CTF_PLAYERS_SPAWN_ZONES`.
  */
 export const PLAYERS_SPAWN_ZONES: SpawnZonesTemplate = {
-  [GAME_TYPES.FFA]: [FFA_SPAWN_EUROPE, FFA_SPAWN_CANADA, FFA_SPAWN_LATAM, FFA_SPAWN_RUSSIA],
+  [GAME_TYPES.FFA]: [FFA_SPAWN_EUROPE, FFA_SPAWN_CANADA, FFA_SPAWN_LATAM, FFA_SPAWN_ASIA],
   [GAME_TYPES.BTR]: [BTR_SPAWN_WAITING, BTR_SPAWN_MATCH_START],
 };

--- a/src/constants/spawn.ts
+++ b/src/constants/spawn.ts
@@ -1,12 +1,12 @@
 import { GAME_TYPES } from '@airbattle/protocol';
 import { SpawnZonesTemplate } from '../types';
 import { BTR_SPAWN_MATCH_START, BTR_SPAWN_WAITING } from './btr';
-import { FFA_SPAWN_EUROPE } from './ffa';
+import { FFA_SPAWN_EUROPE, FFA_SPAWN_CANADA, FFA_SPAWN_LATAM, FFA_SPAWN_RUSSIA } from './ffa';
 
 /**
  * CTF has a custom spawn system. See `CTF_PLAYERS_SPAWN_ZONES`.
  */
 export const PLAYERS_SPAWN_ZONES: SpawnZonesTemplate = {
-  [GAME_TYPES.FFA]: [FFA_SPAWN_EUROPE],
+  [GAME_TYPES.FFA]: [FFA_SPAWN_EUROPE, FFA_SPAWN_CANADA, FFA_SPAWN_LATAM, FFA_SPAWN_RUSSIA],
   [GAME_TYPES.BTR]: [BTR_SPAWN_WAITING, BTR_SPAWN_MATCH_START],
 };

--- a/src/modes/ffa/maintenance/players.ts
+++ b/src/modes/ffa/maintenance/players.ts
@@ -1,4 +1,4 @@
-import { FFA_SPAWN_RUSSIA, FFA_VALID_SPAWN_ZONES, SHIPS_ENCLOSE_RADIUS } from '../../../constants';
+import { FFA_VALID_SPAWN_ZONES, SHIPS_ENCLOSE_RADIUS } from '../../../constants';
 import { PLAYERS_ASSIGN_SPAWN_POSITION } from '../../../events';
 import { System } from '../../../server/system';
 import { getRandomInt } from '../../../support/numbers';

--- a/src/modes/ffa/maintenance/players.ts
+++ b/src/modes/ffa/maintenance/players.ts
@@ -1,4 +1,4 @@
-import { SHIPS_ENCLOSE_RADIUS } from '../../../constants';
+import { FFA_SPAWN_RUSSIA, FFA_VALID_SPAWN_ZONES, SHIPS_ENCLOSE_RADIUS } from '../../../constants';
 import { PLAYERS_ASSIGN_SPAWN_POSITION } from '../../../events';
 import { System } from '../../../server/system';
 import { getRandomInt } from '../../../support/numbers';
@@ -19,9 +19,12 @@ export default class GamePlayers extends System {
     let r = 0;
 
     /**
-     * FFA has only one spawn zone at index 0.
+     * FFA support spawn zone selection.  Zones are defined in constants/ffa.ts.  
+     * A zone can be input by the administrator via the environment, or changed at runtime via a server command.
      */
-    const spawnZones = this.storage.spawnZoneSet.get(0).get(player.planetype.current);
+    let zone = this.config.ffa.spawnZoneName
+    let zoneIndex = FFA_VALID_SPAWN_ZONES[zone] || 0
+    let spawnZones = this.storage.spawnZoneSet.get(zoneIndex).get(player.planetype.current);
 
     [x, y] = spawnZones.get(getRandomInt(0, spawnZones.size - 1));
     r = SHIPS_ENCLOSE_RADIUS[player.planetype.current] / 2;

--- a/src/modes/ffa/periodic/infernos.ts
+++ b/src/modes/ffa/periodic/infernos.ts
@@ -23,6 +23,26 @@ export default class InfernosPeriodic extends System {
         posY: -2800,
         type: MOB_TYPES.INFERNO,
       } as PeriodicPowerupTemplate,
+
+      /**
+       * Blue base inferno.
+       */
+      {
+        interval: 105,
+        posX: -7440,
+        posY: -1360,
+        type: MOB_TYPES.INFERNO,
+      } as PeriodicPowerupTemplate,
+
+      /**
+       * Red base inferno.
+       */
+      {
+        interval: 105,
+        posX: 6565,
+        posY: -935,
+        type: MOB_TYPES.INFERNO,
+      } as PeriodicPowerupTemplate,
     ]);
 
     this.log.debug('Periodic infernos loaded.');

--- a/src/server/commands/server.ts
+++ b/src/server/commands/server.ts
@@ -777,7 +777,7 @@ export default class ServerCommandHandler extends System {
           return;
         }
 
-        applyUpgradeFever(player, this.config.upgrades.fever)
+        applyUpgradeFever(player, this.config.upgrades.fever, true)
         this.emit(RESPONSE_PLAYER_UPGRADE, player.id.current, UPGRADES_ACTION_TYPE.LOST);
       })
     }

--- a/src/server/commands/server.ts
+++ b/src/server/commands/server.ts
@@ -3,6 +3,7 @@ import {
   BYTES_PER_KB,
   CHAT_SUPERUSER_MUTE_TIME_MS,
   CONNECTIONS_SUPERUSER_BAN_MS,
+  FFA_VALID_SPAWN_ZONES,
   LIMITS_DEBUG,
   LIMITS_DEBUG_WEIGHT,
   SECONDS_PER_DAY,
@@ -899,6 +900,26 @@ export default class ServerCommandHandler extends System {
     }
   }
 
+
+  /**
+   * /server spawn [value]
+   *
+   * @param playerId
+   * @param command
+   */
+  private handleSpawnZoneSelection(playerId: PlayerId, command: string): void {
+    const zone = command.substring('spawn '.length);
+
+    if (FFA_VALID_SPAWN_ZONES[zone] !== undefined) {
+      this.cfg.ffa.spawnZoneName = zone
+      this.emit(BROADCAST_CHAT_SERVER_WHISPER, playerId, 'Spawn zone changed to "' + zone + '".');
+    } else {
+      this.emit(BROADCAST_CHAT_SERVER_WHISPER, playerId, 'Spawn zone "' + zone + '" not found in list of eligible zones.');
+    }
+  }
+
+  
+
   /**
    * "/server" command handler.
    *
@@ -1064,6 +1085,12 @@ export default class ServerCommandHandler extends System {
 
       if (command.indexOf('upgrades') === 0) {
         this.handleUpgradesSetupCommand(connectionId, playerId, command);
+
+        return;
+      }
+
+      if (command.indexOf('spawn') === 0) {
+        this.handleSpawnZoneSelection(playerId, command);
 
         return;
       }

--- a/src/server/maintenance/players/connect.ts
+++ b/src/server/maintenance/players/connect.ts
@@ -490,7 +490,7 @@ export default class GamePlayersConnect extends System {
         }were recovered after disconnection.`
       );
     }
-    applyUpgradeFever(player, this.config.upgrades.fever)
+    applyUpgradeFever(player, this.config.upgrades.fever, false)
     if (this.config.upgrades.fever) {
       this.emit(
         BROADCAST_CHAT_SERVER_WHISPER,

--- a/src/server/maintenance/players/respawn.ts
+++ b/src/server/maintenance/players/respawn.ts
@@ -180,9 +180,9 @@ export default class GamePlayersRespawn extends System {
       this.emit(PLAYERS_APPLY_SHIELD, player.id.current, PLAYERS_SPAWN_SHIELD_DURATION_MS);
 
       /**
-       * Check for upgrades fever and apply
+       * Check for upgrades fever and apply.
        */
-      applyUpgradeFever(player, this.config.upgrades.fever)
+      applyUpgradeFever(player, this.config.upgrades.fever, false)
       this.emit(RESPONSE_PLAYER_UPGRADE, player.id.current, UPGRADES_ACTION_TYPE.LOST);
 
       /**

--- a/src/server/maintenance/players/upgrades.ts
+++ b/src/server/maintenance/players/upgrades.ts
@@ -24,31 +24,35 @@ export default class GameUpgrades extends System {
   }
 }
 
-export function applyUpgradeFever(player: Player, fever: Boolean): void {
+export function applyUpgradeFever(player: Player, fever: Boolean, toggle: Boolean): void {
 
   if (fever) {
-    if (player.bot.current) {
-      // bots get a nerf
-      player.upgrades.speed = 3;
-      player.upgrades.defense = 2;
-      player.upgrades.energy = 3;
-      player.upgrades.missile = 3;
-
-    } else {
+    // if we're toggling this, preserve upgrades.
+    if (toggle) {
       // preserve player upgrades
       player.upgrades.amount = player.upgrades.amount + 
         player.upgrades.speed +
         player.upgrades.defense +
         player.upgrades.energy +
         player.upgrades.missile
+    }
 
-      // full boosts
+    // apply upgrades
+    if (player.bot.current) {
+      player.upgrades.speed = 3;
+      player.upgrades.defense = 2;
+      player.upgrades.energy = 3;
+      player.upgrades.missile = 3;
+
+    } else {
       player.upgrades.speed = 5;
       player.upgrades.defense = 5;
       player.upgrades.energy = 5;
       player.upgrades.missile = 5;
     }
-  } else {
+
+  } else if (toggle) {
+    // only zero out upgrades when they're toggled - no other time!
     player.upgrades.speed = 0;
     player.upgrades.defense = 0;
     player.upgrades.energy = 0;


### PR DESCRIPTION
This change adds multiple candidate spawn zones for FFA matches.

The default spawn zone remains in Europe, and three other zones have been created in South America, Canada, and Asia. An environmental var is accepted at startup, or a superuser can set the spawn zone
using /server spawn <zone>.  When the spawn zone is changed, new spawn/respawn events will take place in that zone. Transitions may be a little disruptive.

- infernos for FFA now match CTF
- new zones added to constants, with a note on future expansion
- env vars and server commands
- player spawn event selects a target spawn zone