### PR TITLE
bugfix for fever

### DIFF
--- a/src/server/commands/server.ts
+++ b/src/server/commands/server.ts
@@ -776,7 +776,7 @@ export default class ServerCommandHandler extends System {
           return;
         }
 
-        applyUpgradeFever(player, this.config.upgrades.fever)
+        applyUpgradeFever(player, this.config.upgrades.fever, true)
         this.emit(RESPONSE_PLAYER_UPGRADE, player.id.current, UPGRADES_ACTION_TYPE.LOST);
       })
     }

--- a/src/server/maintenance/players/connect.ts
+++ b/src/server/maintenance/players/connect.ts
@@ -490,7 +490,7 @@ export default class GamePlayersConnect extends System {
         }were recovered after disconnection.`
       );
     }
-    applyUpgradeFever(player, this.config.upgrades.fever)
+    applyUpgradeFever(player, this.config.upgrades.fever, false)
     if (this.config.upgrades.fever) {
       this.emit(
         BROADCAST_CHAT_SERVER_WHISPER,

--- a/src/server/maintenance/players/respawn.ts
+++ b/src/server/maintenance/players/respawn.ts
@@ -180,9 +180,9 @@ export default class GamePlayersRespawn extends System {
       this.emit(PLAYERS_APPLY_SHIELD, player.id.current, PLAYERS_SPAWN_SHIELD_DURATION_MS);
 
       /**
-       * Check for upgrades fever and apply
+       * Check for upgrades fever and apply.
        */
-      applyUpgradeFever(player, this.config.upgrades.fever)
+      applyUpgradeFever(player, this.config.upgrades.fever, false)
       this.emit(RESPONSE_PLAYER_UPGRADE, player.id.current, UPGRADES_ACTION_TYPE.LOST);
 
       /**

--- a/src/server/maintenance/players/upgrades.ts
+++ b/src/server/maintenance/players/upgrades.ts
@@ -24,31 +24,35 @@ export default class GameUpgrades extends System {
   }
 }
 
-export function applyUpgradeFever(player: Player, fever: Boolean): void {
+export function applyUpgradeFever(player: Player, fever: Boolean, toggle: Boolean): void {
 
   if (fever) {
-    if (player.bot.current) {
-      // bots get a nerf
-      player.upgrades.speed = 3;
-      player.upgrades.defense = 2;
-      player.upgrades.energy = 3;
-      player.upgrades.missile = 3;
-
-    } else {
+    // if we're toggling this, preserve upgrades.
+    if (toggle) {
       // preserve player upgrades
       player.upgrades.amount = player.upgrades.amount + 
         player.upgrades.speed +
         player.upgrades.defense +
         player.upgrades.energy +
         player.upgrades.missile
+    }
 
-      // full boosts
+    // apply upgrades
+    if (player.bot.current) {
+      player.upgrades.speed = 3;
+      player.upgrades.defense = 2;
+      player.upgrades.energy = 3;
+      player.upgrades.missile = 3;
+
+    } else {
       player.upgrades.speed = 5;
       player.upgrades.defense = 5;
       player.upgrades.energy = 5;
       player.upgrades.missile = 5;
     }
-  } else {
+
+  } else if (toggle) {
+    // only zero out upgrades when they're toggled - no other time!
     player.upgrades.speed = 0;
     player.upgrades.defense = 0;
     player.upgrades.energy = 0;


### PR DESCRIPTION
Upgrade fever was broken! It zeroed out upgrades whenever a player
was killed.  Also when a fever event was ongoing players would
recieve 12 upgrades each time they were killed.