### PR TITLE
Rate limits for assigning sequence ids and sending sync updates

### DIFF
--- a/src/server/periodic/sync.ts
+++ b/src/server/periodic/sync.ts
@@ -31,8 +31,10 @@ export default class SyncUpdatePeriodic extends System {
 
       /**
        * Updates waiting for sequence id.
+       *
+       * Process one update each tick.
        */
-      while (sync.updatesAwaitingSequenceId.length > 0) {
+      if (sync.updatesAwaitingSequenceId.length > 0) {
         const sequence = sync.nextSequenceId;
         const update = sync.updatesAwaitingSequenceId[0];
 
@@ -59,8 +61,12 @@ export default class SyncUpdatePeriodic extends System {
 
       /**
        * Updates waiting for send.
+       *
+       * Send one update each tick.
        */
-      sync.updatesAwaitingSend.forEach((update, sequence) => {
+      if (sync.updatesAwaitingSend.size > 0) {
+        const [sequence, update] = sync.updatesAwaitingSend.entries().next().value;
+
         this.log.debug('Sending sync update %d: %o', sequence, update);
 
         /**
@@ -98,7 +104,7 @@ export default class SyncUpdatePeriodic extends System {
          * Changes made to saveable sync state.
          */
         hasChanges = true;
-      });
+      }
 
       sync.hasChanges = sync.hasChanges || hasChanges;
     }


### PR DESCRIPTION
This limits the actions in `SyncUpdatePeriodic.sendUpdates()` so sequence ids are assigned and `SYNC_UPDATE` packets are sent at a rate of only one per tick.

The purpose of this is to avoid performance issues if the sync service is down for an extended period of time, as happened earlier this month: as players continued to generate sync updates, the `updatesAwaitingSend` queue on each game server became too large to be processed within one tick, when the sync service came back online. In fact, these queues were too large to complete sending all updates within the acknowledgement timeout, so no queued items ended up being cleared (as `SyncUpdatePeriodic.processAckTimeoutsAndResends()` was executed before the incoming `SYNC_ACK` packets could be processed), and the sync service had to be taken offline until this was fixed.

I've already applied this change on `eu-ffa1`, `eu-btr1` and `us-btr1`. It cleared tens of thousands of enqueued sync updates successfully, within a few minutes, with only a minor performance impact (some frame skips).