### PR TITLE
Configurable firewall speed and match wait time for BTR

### DIFF
--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -56,6 +56,18 @@ Automatically add prefix to bot names, helps to prevent mimicry. Non-bot players
 
 Example: `"[bot] "` (don't forget a space at the end if you want to use it as separator), the bot with a requested name `Lunokhod` will receive an assigned name `[bot] Lunokhod`.
 
+### BTR_FIREWALL_SPEED
+
+Default: 70
+
+Speed of firewall as it burns toward centre of map, in map units per second.
+
+### BTR_MATCH_WAIT_TIME
+
+Default: 70
+
+Number of seconds to wait between matches.
+
 ### CACHE_PATH
 
 Default: `../cache`

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -9,6 +9,8 @@ import {
   BOTS_IP_LIST_ENABLED,
   BOTS_SERVER_BOT_FLAG,
   BOTS_SERVER_BOT_NAME,
+  BTR_DEFAULT_FIREWALL_SPEED,
+  BTR_DEFAULT_MATCH_WAIT_TIME,
   CONNECTIONS_DEFAULT_MAX_PLAYERS_PER_IP,
   CONNECTIONS_FLOODING_AUTOBAN,
   CONNECTIONS_INVALID_PROTOCOL_AUTOKICK,
@@ -338,6 +340,18 @@ export interface GameServerConfigInterface {
     baseInfernos: boolean;
   };
 
+  btr: {
+    /**
+     * Speed of firewall as it moves toward the centre of the map.
+     */
+    firewallSpeed: number;
+
+    /**
+     * Wait time between matches.
+     */
+    matchWaitTime: number;
+  };
+
   bots: {
     /**
      * Enable or disable allowed IP list.
@@ -626,6 +640,11 @@ const config: GameServerConfigInterface = {
   ffa: {
     spawnZoneName: strValue(process.env.FFA_SPAWN_ZONE_NAME, FFA_DEFAULT_SPAWN_ZONE),
     baseInfernos: boolValue(process.env.FFA_BASE_INFERNOS, false),
+  },
+
+  btr: {
+    firewallSpeed: intValue(process.env.BTR_FIREWALL_SPEED, BTR_DEFAULT_FIREWALL_SPEED),
+    matchWaitTime: intValue(process.env.BTR_MATCH_WAIT_TIME, BTR_DEFAULT_MATCH_WAIT_TIME),
   },
 };
 

--- a/src/constants/btr.ts
+++ b/src/constants/btr.ts
@@ -12,7 +12,9 @@ export const BTR_FIREWALL_POSITION = {
 
 export const BTR_FIREWALL_INITIAL_RADIUS = 17000;
 
-export const BTR_FIREWALL_SPEED = -70;
+export const BTR_DEFAULT_FIREWALL_SPEED = 70;
+
+export const BTR_DEFAULT_MATCH_WAIT_TIME = 70;
 
 export const BTR_SHIPS_TYPES_ORDER = [
   SHIPS_TYPES.PREDATOR,

--- a/src/modes/btr/responses/broadcast/game-firewall.ts
+++ b/src/modes/btr/responses/broadcast/game-firewall.ts
@@ -1,5 +1,4 @@
 import { ServerPackets, SERVER_PACKETS } from '@airbattle/protocol';
-import { BTR_FIREWALL_SPEED } from '../../../../constants';
 import { BROADCAST_GAME_FIREWALL, CONNECTIONS_SEND_PACKETS } from '../../../../events';
 import { System } from '../../../../server/system';
 import { PlayerId } from '../../../../types';
@@ -35,7 +34,7 @@ export default class GameFirewallBroadcast extends System {
         posX: firewall.posX,
         posY: firewall.posY,
         radius: firewall.radius,
-        speed: BTR_FIREWALL_SPEED,
+        speed: firewall.speed,
       } as ServerPackets.GameFirewall,
       playerId === null
         ? [...this.storage.mainConnectionIdList]


### PR DESCRIPTION
In response to player feedback that Battle Royale games progress too slowly, this change permits configuration of the firewall speed and the wait time before the next match commences.

Currently, it is being tested on US BTR with a match wait time of 35 seconds and a firewall speed of 175 map units per second.