### PR TITLE
Limits for the /s chat command

### DIFF
--- a/src/server/controllers/say.ts
+++ b/src/server/controllers/say.ts
@@ -1,5 +1,5 @@
 import { ClientPackets } from '@airbattle/protocol';
-import { CHAT_SAY, ROUTE_SAY } from '../../events';
+import { CHAT_CHECK_LIMITS, CHAT_SAY, ROUTE_SAY } from '../../events';
 import { CHANNEL_CHAT } from '../../events/channels';
 import { MainConnectionId } from '../../types';
 import { System } from '../system';
@@ -25,6 +25,15 @@ export default class SayMessageHandler extends System {
     }
 
     const connection = this.storage.connectionList.get(connectionId);
+    
+    /**
+     * Skip spam messages.
+     */
+    if (connection.limits.chat > this.config.connections.packetLimits.chat) {
+      return;
+    }
+
+    this.emit(CHAT_CHECK_LIMITS, connection);
 
     if (!this.helpers.isPlayerMuted(connection.playerId)) {
       this.channel(CHANNEL_CHAT).delay(CHAT_SAY, connection.playerId, msg.text);

--- a/src/server/controllers/say.ts
+++ b/src/server/controllers/say.ts
@@ -29,7 +29,7 @@ export default class SayMessageHandler extends System {
     /**
      * Skip spam messages.
      */
-    if (connection.limits.chat > this.config.connections.packetLimits.chat) {
+    if (connection.limits.say > this.config.connections.packetLimits.chat) {
       return;
     }
 

--- a/src/server/maintenance/players/update.ts
+++ b/src/server/maintenance/players/update.ts
@@ -928,7 +928,12 @@ export default class GamePlayersUpdate extends System {
           limits.chat < this.config.connections.packetLimits.chatLeak
             ? 0
             : limits.chat - this.config.connections.packetLimits.chatLeak;
-
+        
+        limits.say =
+          limits.say < this.config.connections.packetLimits.chatLeak
+            ? 0
+            : limits.say - this.config.connections.packetLimits.chatLeak;
+        
         limits.respawn =
           limits.respawn < LIMITS_RESPAWN_DECREASE_WEIGHT
             ? 0


### PR DESCRIPTION
Updated description (by wight):

Changes to prevent the chat blocking. Initially, `/s` has no usage limitations and because it shares the `CHANNEL_CHAT` queue with other chats (public and team), spamming with `/s` can block the ability to write to these chats. Context: https://www.reddit.com/r/airmash/comments/z2z6mn/hey_cut_it_out_chat_say_bb/



Original post:

> pretty sure i did it now